### PR TITLE
Better stats output + New UndesiredGauge stat

### DIFF
--- a/replicator/replicator.go
+++ b/replicator/replicator.go
@@ -207,6 +207,9 @@ func (srv *Service) updateUndesiredState(desiredUnits, undesiredUnits []Unit) er
 			}
 		}
 	}
+
+	srv.stats.UndesiredUnitsGauge(len(srv.undesiredState))
+
 	return nil
 }
 

--- a/replicator/stats.go
+++ b/replicator/stats.go
@@ -2,41 +2,52 @@ package replicator
 
 import "github.com/golang/glog"
 
-func logStats(s string, n int) {
-	glog.Infof("[STATS] %s = %d\n", s, n)
+func logStatsCounter(s string, delta int) {
+	if delta >= 0 {
+		glog.Infof("[STATS] %s: +%d\n", s, delta)
+	} else {
+		glog.Infof("[STATS] %s: %d\n", s, delta)
+	}
+
+}
+func logStatsGauge(s string, n int) {
+	glog.Infof("[STATS] %s: %d\n", s, n)
 }
 
 type Stats struct{}
 
 func (stats *Stats) SeenMachinesTotal(count int) {
-	logStats("seenMachinesTotal", count)
+	logStatsGauge("seenMachinesTotal", count)
 }
 func (stats *Stats) SeenMachinesActive(count int) {
-	logStats("seenMachinesActive", count)
+	logStatsGauge("seenMachinesActive", count)
 }
 
 func (stats *Stats) SeenManagedUnits(count int) {
-	logStats("ManagedFleetUnits", count)
+	logStatsGauge("ManagedFleetUnits", count)
 }
 
 func (stats *Stats) MarkNewUndesiredUnit(unit Unit) {
-	logStats("MarkNewUndesiredUnit", 1)
+	logStatsCounter("MarkNewUndesiredUnit", 1)
 }
 func (stats *Stats) MarkUndesiredUnitBackToDesired(unit Unit) {
-	logStats("MarkUndesiredUnitBackToDesired", 1)
+	logStatsCounter("MarkUndesiredUnitBackToDesired", 1)
 }
 func (stats *Stats) DeleteUndesiredUnit(unit Unit) {
-	logStats("DeleteUnit", 1)
+	logStatsCounter("DeleteUnit", 1)
+}
+func (stats *Stats) UndesiredUnitsGauge(g int) {
+	logStatsGauge("UndesiredUnits", g)
 }
 
 func (stats *Stats) MarkActiveUnitNoUpdateRequired(unit Unit) {
-	logStats("MarkActiveUnitNoUpdateRequired", 1)
+	logStatsCounter("MarkActiveUnitNoUpdateRequired", 1)
 }
 
 func (stats *Stats) MarkActiveUnitUpdateRequired(unit Unit) {
-	logStats("MarkActiveUnitUpdateRequired", 1)
+	logStatsCounter("MarkActiveUnitUpdateRequired", 1)
 }
 
 func (stats *Stats) UpdateUnitIgnoredCooldown(unit Unit) {
-	logStats("UpdateUnitIgnoredCooldown", 1)
+	logStatsCounter("UpdateUnitIgnoredCooldown", 1)
 }


### PR DESCRIPTION
Just tested with Hugo what happens when we rotate a machine and apply a new machine-id. 
Since we only log `NewUndesiredUnits` but the machine came up with a new machine-id it was not totally clear from the logs what the internal thinking was.

Having a clearer stats output about the number of known "undesired" units would have been helpful.
