### PR TITLE
Add SIGUSR1 support to reset cooldown timer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ $(BIN): VERSION $(SOURCE)
 	    -e GOARCH=$(GOARCH) \
 	    -w /usr/code \
 	    golang:1.6 \
-	    go build -a -ldflags "-X main.projectVersion $(VERSION) -X main.projectBuild $(COMMIT)" -o $(BIN)
+	    go build -a -ldflags "-X main.projectVersion=$(VERSION) -X main.projectBuild=$(COMMIT)" -o $(BIN)
 
 run-tests:
 	@make run-test test=./...

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ deps:
 	@GOPATH=$(GOPATH) builder go get github.com/golang/glog
 	@GOPATH=$(GOPATH) builder go get github.com/golang/protobuf/proto
 	@builder get dep -b v0.8.8 git@github.com:influxdb/influxdb.git $(BUILD_PATH)/src/github.com/influxdb/influxdb
-	
-	
+
+
 	# @GOPATH=$(GOPATH) builder go get github.com/inhies/go-tld
 	#
 	# Build test packages (we only want those two, so we use `-d` in go get)
@@ -89,10 +89,10 @@ $(BIN): VERSION $(SOURCE)
 	    -e GOOS=$(GOOS) \
 	    -e GOARCH=$(GOARCH) \
 	    -w /usr/code \
-	    golang:1.4.2-cross \
+	    golang:1.6 \
 	    go build -a -ldflags "-X main.projectVersion $(VERSION) -X main.projectBuild $(COMMIT)" -o $(BIN)
 
-run-tests: 
+run-tests:
 	@make run-test test=./...
 
 run-test:
@@ -105,7 +105,7 @@ run-test:
 	    -v $(shell pwd):/usr/code \
 	    -e GOPATH=/usr/code/.gobuild \
 	    -w /usr/code \
-	    golang:1.4.2-cross \
+	    golang:1.6 \
 	    go test -v $(test)
 
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Dynamically schedule fleet units based on available fleet machines.
 
 The fleet-unit-replicator compiles from the list of machines in fleet and the provided configuration a list of units that needs to be running. This is compared to the list of units in fleet and appropriate actions are taken:
 
-* For new machines, new units are scheduled based on the template
+* For new machines, new units are scheduled based on the template immediately
 * For existing units, the unitfile is fetched and compared. If unequal, an update is performed when allowed (see Update Cooldown Time)
 * If units are detected that have no "living" machine, they are marked for deletion after the deletion cooldown time.
+
+If you are confident the units are running already and you don't want to wait until `cooldown time` is over, send a `SIGUSR1` to the fleet-unit-replicator, to reset the timer. Upon the next tick, the next unit file will be updated.
 
 
 ## Concepts
@@ -14,4 +16,3 @@ The fleet-unit-replicator compiles from the list of machines in fleet and the pr
  * __delete cooldown time__: To prevent the replicator is running amok, we have a cooldown time for each unit before its getting deleted. By default a unit must be reported as undesired for 60 minutes before we delete it.
 
  * __update cooldown time__: To prevent the replicator to teardown the whole data services at once and thus rendering everything offline, a cooldown time is applied between updates. Detected updates while within a cooldown phase are ignored.
-

--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func main() {
 	go repl.Serve()
 
 	ch := make(chan os.Signal)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
 
 	for {
 		signal := <-ch

--- a/main.go
+++ b/main.go
@@ -190,8 +190,21 @@ func main() {
 
 	ch := make(chan os.Signal)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	<-ch
 
+	for {
+		signal := <-ch
+
+		switch signal {
+		case syscall.SIGINT, syscall.SIGTERM:
+			goto shutdown
+		case syscall.SIGUSR1:
+			repl.ResetCooldowntime()
+		default:
+			glog.Warning("Unknown signal: %s", signal)
+		}
+	}
+
+shutdown:
 	glog.Info("Received termination signal. Closing ...")
 	repl.Stop()
 }

--- a/replicator/replicator.go
+++ b/replicator/replicator.go
@@ -85,16 +85,16 @@ func (srv *Service) Serve() {
 		glog.Fatalf("%v", err)
 	}
 
-	for range srv.ticker.C {
+	for {
 		select {
 		case <-srv.ticker.C:
 			if err := r(); err != nil {
 				glog.Fatalf("%v", err)
 			}
 		case <-srv.resetCooldowntime:
+			glog.Infof("Resetting cooldown time. Was at %s", srv.lastUpdate.RemainingTime())
 			srv.lastUpdate.SetFalse()
 		}
-
 	}
 }
 

--- a/replicator/replicator.go
+++ b/replicator/replicator.go
@@ -72,7 +72,7 @@ func (srv *Service) Serve() {
 
 	r := func() error {
 		glog.Info("*tick*")
-		glog.Info("Time until lastUpdate resets: %v", srv.lastUpdate.RemainingTime())
+		glog.Infof("Time until lastUpdate resets: %s", srv.lastUpdate.RemainingTime())
 		srv.shutdownWG.Add(1)
 		defer func() {
 			srv.shutdownWG.Done()

--- a/replicator/replicator.go
+++ b/replicator/replicator.go
@@ -368,7 +368,7 @@ func NewExpiringBool(cooldown time.Duration) *ExpiringBool {
 	}
 }
 
-// CooldownTime represents kindof a boolean that keeps its 'true' state only for a certain
+// ExpiringBool represents kindof a boolean that keeps its 'true' state only for a certain
 // amount of time.
 type ExpiringBool struct {
 	CooldownTime time.Duration


### PR DESCRIPTION
This PR does three things
- Handle SIGUSR1 to reset the cooldown time
- Build with golang 1.6
- Print the remaining cooldown time on the beginning of each tick
